### PR TITLE
Change reference of "decopolis.ini" to "Decopolis.ini" for *nix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,7 @@ namespace Merthsoft.DecBot3
 			[Option(shortName: 'l', longName: "logfile", Required = false, HelpText = "Name of a file to log to, or stderr by default", Default = null)]
 			public string LogPath { get; set; }
 
-			[Value(index: 0, Default = "decopolis.ini", HelpText = "Path to the configuration file to use")]
+			[Value(index: 0, Default = "Decopolis.ini", HelpText = "Path to the configuration file to use")]
 			public string ConfigFile { get; set; }
 		}
 


### PR DESCRIPTION
On Windows, filenames are not case-sensitive. On Linux, filenames *are* case-sensitive. This may or may not be necessary, but I think it should be fixed anyway.